### PR TITLE
feat(API): Add root path support for web interface

### DIFF
--- a/docstrange/cli.py
+++ b/docstrange/cli.py
@@ -175,7 +175,8 @@ Examples:
   
   # Start web interface
   docstrange web                     # Start web interface at http://localhost:8000
-  
+  docstrange web --root-path /docstrange  # Start at http://localhost:8000/docstrange
+
   # Convert a PDF to markdown (default cloud mode)
   docstrange document.pdf
 
@@ -338,7 +339,13 @@ docstrange document.pdf --model nanonets --output csv
         action="store_true",
         help="Clear cached authentication credentials"
     )
-    
+
+    parser.add_argument(
+        "--root-path",
+        default="",
+        help="Root path for the web server (e.g., '/docstrange'). Only used with 'web' command."
+    )
+
     args = parser.parse_args()
     
     # Handle version flag
@@ -368,9 +375,10 @@ docstrange document.pdf --model nanonets --output csv
         try:
             from .web_app import run_web_app
             print("Starting DocStrange web interface...")
-            print("Open your browser and go to: http://localhost:8000")
+            base_url = f"http://localhost:8000{args.root_path}" if args.root_path else "http://localhost:8000"
+            print(f"Open your browser and go to: {base_url}")
             print("Press Ctrl+C to stop the server")
-            run_web_app(host='0.0.0.0', port=8000, debug=False)
+            run_web_app(host='0.0.0.0', port=8000, debug=False, root_path=args.root_path)
             return 0
         except ImportError:
             print("❌ Web interface not available. Install Flask: pip install Flask", file=sys.stderr)

--- a/docstrange/static/script.js
+++ b/docstrange/static/script.js
@@ -4,6 +4,8 @@ class DocStrangeApp {
     constructor() {
         this.selectedFile = null;
         this.extractionResults = null;
+        // Get root path from global config, default to empty string
+        this.rootPath = window.APP_ROOT_PATH || '';
         this.initializeApp();
     }
 
@@ -14,7 +16,7 @@ class DocStrangeApp {
 
     async loadSystemInfo() {
         try {
-            const response = await fetch('/api/system-info');
+            const response = await fetch(`${this.rootPath}/api/system-info`);
             if (response.ok) {
                 const systemInfo = await response.json();
                 this.updateProcessingModeOptions(systemInfo);
@@ -169,7 +171,7 @@ class DocStrangeApp {
             // Use cloud processing mode by default
             formData.append('processing_mode', 'cloud');
 
-            const response = await fetch('/api/extract', {
+            const response = await fetch(`${this.rootPath}/api/extract`, {
                 method: 'POST',
                 body: formData
             });

--- a/docstrange/templates/index.html
+++ b/docstrange/templates/index.html
@@ -591,6 +591,12 @@
     </style>
 </head>
 <body>
+    <!-- Root path configuration -->
+    <script>
+        // Global configuration for API paths
+        window.APP_ROOT_PATH = '{{ root_path }}';
+    </script>
+
     <!-- Header -->
     <header class="main-header">
         <div class="header-logo-section">
@@ -996,12 +1002,13 @@
                 formData.append('file', file);
                 formData.append('output_format', format === 'json' ? 'flat-json' : format);
                 formData.append('processing_mode', 'cloud');
-                
+
                 // Show loading state
                 extractBtn.textContent = 'Processing...';
                 extractBtn.disabled = true;
-                
-                fetch('/api/extract', {
+
+                const rootPath = window.APP_ROOT_PATH || '';
+                fetch(`${rootPath}/api/extract`, {
                     method: 'POST',
                     body: formData
                 })

--- a/docstrange/web_app.py
+++ b/docstrange/web_app.py
@@ -195,12 +195,24 @@ def get_system_info():
     
     return jsonify(system_info)
 
-def run_web_app(host='0.0.0.0', port=8000, debug=False):
-    """Run the web application."""
+def run_web_app(host='0.0.0.0', port=8000, debug=False, root_path=''):
+    """Run the web application.
+
+    Args:
+        host: Host to bind to
+        port: Port to bind to
+        debug: Enable debug mode
+        root_path: Root path for the application (e.g., '/docstrange')
+    """
+    # Configure root path if provided
+    if root_path:
+        app.config['APPLICATION_ROOT'] = root_path
+        print(f"📍 Application root path set to: {root_path}")
+
     # Check GPU availability before starting the server
     print("🔍 Checking GPU availability...")
     gpu_available = check_gpu_availability()
-    
+
     if not gpu_available:
         error_msg = (
             "❌ GPU is not available! DocStrange requires GPU for optimal performance.\n"
@@ -214,11 +226,13 @@ def run_web_app(host='0.0.0.0', port=8000, debug=False):
         )
         print(error_msg)
         raise RuntimeError("GPU is not available. DocStrange requires GPU for optimal performance.")
-    
+
     print("✅ GPU detected - proceeding with model download...")
     print("🔄 Downloading models before starting the web interface...")
     download_models()
-    print(f"✅ Starting docstrange web interface at http://{host}:{port}")
+
+    base_url = f"http://{host}:{port}{root_path}" if root_path else f"http://{host}:{port}"
+    print(f"✅ Starting docstrange web interface at {base_url}")
     print("Press Ctrl+C to stop the server")
     app.run(host=host, port=port, debug=debug)
 

--- a/docstrange/web_app.py
+++ b/docstrange/web_app.py
@@ -75,7 +75,8 @@ extractor = DocumentExtractor()
 @app.route('/')
 def index():
     """Serve the main page."""
-    return render_template('index.html')
+    root_path = app.config.get('APPLICATION_ROOT', '')
+    return render_template('index.html', root_path=root_path)
 
 @app.route('/static/<path:filename>')
 def static_files(filename):


### PR DESCRIPTION
This pull request adds support for specifying a custom root path for the DocStrange web interface, improving flexibility for deployments under subpaths (such as behind a reverse proxy). The changes include new CLI options, updates to user instructions and output, and configuration in the web server to honor the root path.

### CLI enhancements

* Added a `--root-path` argument to the CLI, allowing users to specify a custom root path for the web interface (e.g., `/docstrange`). This is only used with the `web` command.

### Web server configuration

* Updated the `run_web_app` function in `docstrange/web_app.py` to accept a `root_path` argument and configure the Flask application’s `APPLICATION_ROOT` accordingly. This ensures proper routing when the app is served under a subpath.
* Pass the `root_path` value to the static content (index.html, script.js) so that the frontend can hit the proper endpoints

### Static Content

* Updated the index.html (template) to store the root_path for use on frontend resources
* Updated script.js to use the root_path if present (fallback to '') to make calls to the proper api location

@Siddhant011 @prats226 